### PR TITLE
LTE: Add Verizon mobile carrier support

### DIFF
--- a/src/app/setup/components/LteForm.js
+++ b/src/app/setup/components/LteForm.js
@@ -116,7 +116,8 @@ Ext.define('Mfw.setup.cmp.Lte', {
             bind: {
                 value: '{intf.simApn}',
                 required: '{intf.type === "WWAN" && intf.enabled}',
-                disabled: '{!intf.enabled || intf.simNetwork}'
+                disabled: '{!intf.enabled || intf.simNetwork}',
+                hidden: '{intf.simApn === "any"}'
             }
         },
         // {

--- a/src/common/Map.js
+++ b/src/common/Map.js
@@ -950,7 +950,8 @@ Ext.define('Mfw.settings.Map', {
         ],
 
         simNetworks: [
-            { text: 'T-Mobile', value: 'T-Mobile', apn: 'fast.t-mobile.com' }
+            { text: 'T-Mobile', value: 'T-Mobile', apn: 'fast.t-mobile.com' },
+            { text: 'Verizon', value: 'Verizon', apn: 'any' }
             // MFW-739 do not show other LTE networks
             // { text: 'Other', value: 'OTHER' }
         ]

--- a/src/package/settings/view/network/interface/Lte.js
+++ b/src/package/settings/view/network/interface/Lte.js
@@ -92,6 +92,7 @@ Ext.define('Mfw.settings.interface.Lte', {
                     xtype: 'selectfield',
                     label: 'Network',
                     margin: '0 16 0 0',
+                    maxWidth: '150',
                     options: Map.options.simNetworks,
                     placeholder: 'Select network provider ...',
                     forceSelection: true,
@@ -109,7 +110,8 @@ Ext.define('Mfw.settings.interface.Lte', {
                     bind: {
                         value: '{intf.simApn}',
                         required: '{intf.type === "WWAN"}',
-                        disabled: '{intf.type !== "WWAN" || intf.simNetwork}'
+                        disabled: '{intf.type !== "WWAN" || intf.simNetwork}',
+                        hidden: '{intf.simApn === "any"}'
                     }
                 }]
             },


### PR DESCRIPTION
The apn doesn't matter for Verizon, so we use the value of any.
In that case, don't bother showing the APN value in the setup
wizard or interface properties

MFW-896