### PR TITLE
Fix Interface Usage graph to ignore LAN interfaces

### DIFF
--- a/reports/interfaces/interface_usage.json
+++ b/reports/interfaces/interface_usage.json
@@ -15,6 +15,11 @@
     "querySeries": {
         "timeIntervalSeconds": 60
     },
+    "conditions": [{
+        "column": "is_wan",
+        "operator": "EQ",
+        "value": "1"
+    }],
     "rendering": {
         "type": "spline",
         "lineWidth": 2,


### PR DESCRIPTION
The original fix for MFW-749 turned off logging of stats for LAN
interfaces. This solved the original issue but removed the stats
from other areas where we want them to display. I updated packetd
with a new is_wan boolean in the interface_stats table and turned
stats logging back on for both WAN and LAN interfaces.
With those changes, I then made this update to include a condition
on the is_wan column in the json for the interface usage graph.