### PR TITLE
Fix the natEgress flag for VLAN interfaces

### DIFF
--- a/src/package/settings/view/network/InterfacesController.js
+++ b/src/package/settings/view/network/InterfacesController.js
@@ -11,7 +11,7 @@ Ext.define('Mfw.settings.network.InterfacesController', {
                 configType: 'ADDRESSED',
                 wan: false,
                 v4ConfigType: 'STATIC',
-                natEgress: true
+                natEgress: false
             })
         }
 


### PR DESCRIPTION
I think by default we do not want to NAT traffic going out VLAN interfaces as it could cause difficulties in LAN environments. If at some point we think users need this functionality, we should considering adding checkboxes to enable/disable ingress and egress.
