### PR TITLE
Mfw 1132 vlan isolation

### DIFF
--- a/src/package/settings/store/Conditions.js
+++ b/src/package/settings/store/Conditions.js
@@ -248,7 +248,7 @@ Ext.define('Mfw.settings.Conditions', {
         operators: ['==', '!='],
         field: {
             xtype: 'selectfield',
-            multiSelect: true,
+            multiSelect: false,
             editable: false,
             itemTpl: '{text} <span style="color: #999">[ {value} ]</span>',
             chipView: {
@@ -333,7 +333,7 @@ Ext.define('Mfw.settings.Conditions', {
         disableOnFirstPacket: true,
         field: {
             xtype: 'selectfield',
-            multiSelect: true,
+            multiSelect: false,
             editable: false,
             itemTpl: '{text} <span style="color: #999">[ {value} ]</span>',
             chipView: {
@@ -423,7 +423,7 @@ Ext.define('Mfw.settings.Conditions', {
         operators: ['==', '!='],
         field: {
             xtype: 'selectfield',
-            multiSelect: true,
+            multiSelect: false,
             editable: false,
             itemTpl: '{text} <span style="color: #999">[ {value} ]</span>',
             chipView: {
@@ -513,7 +513,7 @@ Ext.define('Mfw.settings.Conditions', {
         operators: ['==', '!='],
         field: {
             xtype: 'selectfield',
-            multiSelect: true,
+            multiSelect: false,
             editable: false,
             itemTpl: '{text} <span style="color: #999">[ {value} ]</span>',
             chipView: {

--- a/src/package/settings/view/network/InterfacesController.js
+++ b/src/package/settings/view/network/InterfacesController.js
@@ -11,7 +11,7 @@ Ext.define('Mfw.settings.network.InterfacesController', {
                 configType: 'ADDRESSED',
                 wan: false,
                 v4ConfigType: 'STATIC',
-                natEgress: true
+                natEgress: false
             })
         }
 

--- a/src/package/settings/view/network/InterfacesController.js
+++ b/src/package/settings/view/network/InterfacesController.js
@@ -11,7 +11,7 @@ Ext.define('Mfw.settings.network.InterfacesController', {
                 configType: 'ADDRESSED',
                 wan: false,
                 v4ConfigType: 'STATIC',
-                natEgress: false
+                natEgress: true
             })
         }
 


### PR DESCRIPTION
I modified the interface zone condition definitions so they are no longer multiSelect, since we can't match multiple values in a rule mark mask expression. I also restored the previous default for natEgress for VLAN until we're able to do a deeper dive/review of how to handle VLAN interfaces.