### PR TITLE
Interface: Identify new wan interfaces

### DIFF
--- a/src/package/settings/view/network/Interface.js
+++ b/src/package/settings/view/network/Interface.js
@@ -913,6 +913,16 @@ Ext.define('Mfw.settings.network.Interface', {
             }
 
             if (isNew) {
+
+                /**
+                 * If the new interface is a wan, add a 'new' field
+                 * which allows sync-settings to know that it should
+                 * create a new wan policy for this interface
+                 */
+                if (intf.get('wan')) {
+                    intf.set('new', true);
+                }
+
                 interfacesStore.add(intf);
             } else {
                 intf.commit();


### PR DESCRIPTION
By adding the 'new' property to new wan interfaces, sync-settings
can detect when a new wan interface has been created and create a
new wan policy for it automatically

MFW-1124