### PR TITLE
LTE: Add AT&T support

### DIFF
--- a/src/common/Map.js
+++ b/src/common/Map.js
@@ -951,7 +951,8 @@ Ext.define('Mfw.settings.Map', {
 
         simNetworks: [
             { text: 'T-Mobile', value: 'T-Mobile', apn: 'fast.t-mobile.com' },
-            { text: 'Verizon', value: 'Verizon', apn: 'any' }
+            { text: 'Verizon', value: 'Verizon', apn: 'any' },
+            { text: 'AT&T', value: 'AT&T', apn: 'm2m.com.attz' }
             // MFW-739 do not show other LTE networks
             // { text: 'Other', value: 'OTHER' }
         ]

--- a/src/package/settings/view/network/interface/Lte.js
+++ b/src/package/settings/view/network/interface/Lte.js
@@ -109,8 +109,8 @@ Ext.define('Mfw.settings.interface.Lte', {
                     placeholder: 'Enter APN ...',
                     bind: {
                         value: '{intf.simApn}',
-                        required: '{intf.type === "WWAN"}',
-                        disabled: '{intf.type !== "WWAN" || intf.simNetwork}',
+                        required: '{intf.type === "WWAN" && intf.simNetwork !== "AT&T"}',
+                        disabled: '{intf.type !== "WWAN" || (intf.simNetwork && intf.simNetwork !== "AT&T")}',
                         hidden: '{intf.simApn === "any"}'
                     }
                 }]


### PR DESCRIPTION
Add AT&T to the supported network list with a default apn
of m2m.com.attz.  But, allow the user to change the apn, or
to have no apn at all.

MFW-1032