### PR TITLE
Don't replace null with 0 for charts with ms units

### DIFF
--- a/src/package/reports/view/ChartController.js
+++ b/src/package/reports/view/ChartController.js
@@ -518,7 +518,16 @@ Ext.define('Mfw.reports.ChartController', {
                         if (!series[key]) {
                             series[key] = { name: (name !== '<nil>') ? name : 'none', data: [] };
                         } else {
-                            series[key].data.push([d.time_trunc, val || 0]);
+                            /*
+                             * When units are ms, it doesn't make sense to convert null
+                             * values to 0.  Just leave them as null so they are rendered
+                             * as gaps in the chart data
+                             */
+                            if (record.get('units') === 'ms') {
+                                series[key].data.push([d.time_trunc, val]);
+                            } else {
+                                series[key].data.push([d.time_trunc, val || 0]);
+                            }
                         }
                     }
                 });


### PR DESCRIPTION
For charts with milliseconds for units, it doesn't really make
sense to render null data as zero.  Just leave the nulls in this
case so the null data is rendered as gaps in the chart

MFW-1088