### PR TITLE
Tweak vlan natEgress logic

### DIFF
--- a/src/package/settings/view/network/Interface.js
+++ b/src/package/settings/view/network/Interface.js
@@ -1106,13 +1106,21 @@ Ext.define('Mfw.settings.network.Interface', {
          */
         handleVlanSelect: function(item, record) {
             var vm = this.getViewModel(),
+                wan = record.get('wan'),
+                was_wan = vm.get('intf.wan'),
                 configType = record.get('configType');
 
             if(record && vm) {
                 if(configType === 'ADDRESSED') {
-                    vm.set('intf.wan', record.get('wan'));
+                    vm.set('intf.wan', wan);
+                    if(wan && !was_wan) {
+                        vm.set('intf.natEgress', true);
+                    } else if(!wan) {
+                        vm.set('intf.natEgress', false);
+                    }
                 } else {
                     vm.set('intf.wan', false);
+                    vm.set('intf.natEgress', false);
                 }
             }
         },

--- a/src/package/settings/view/network/InterfacesController.js
+++ b/src/package/settings/view/network/InterfacesController.js
@@ -11,7 +11,7 @@ Ext.define('Mfw.settings.network.InterfacesController', {
                 configType: 'ADDRESSED',
                 wan: false,
                 v4ConfigType: 'STATIC',
-                natEgress: true
+                natEgress: false
             })
         }
 


### PR DESCRIPTION
When a vlan is created, if its parent is not a wan, natEgress
is disabled and cannot be enabled.  If its parent is a wan, then
natEgress for the vlan will default to the same value as its parent,
but the user will be able to change it via the checkbox.

MFW-1174